### PR TITLE
fix(updater): add Aliyun OSS as fallback update source

### DIFF
--- a/.github/workflows/release-and-build.yml
+++ b/.github/workflows/release-and-build.yml
@@ -287,10 +287,15 @@ jobs:
         run: |
           mkdir -p dist
           # 动态检索并统一拷贝各平台的发布二进制包
+          # 注：除 .exe/.dmg/.AppImage/.deb 外，还需上传 updater manifest 引用的
+          #     .msi / .app.tar.gz / .rpm，否则 OSS 兜底更新时这些文件会 404
           find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.exe" -exec cp {} dist/ \; 2>/dev/null || true
+          find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.msi" -exec cp {} dist/ \; 2>/dev/null || true
           find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.dmg" -exec cp {} dist/ \; 2>/dev/null || true
+          find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.app.tar.gz" -exec cp {} dist/ \; 2>/dev/null || true
           find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.AppImage" -exec cp {} dist/ \; 2>/dev/null || true
           find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.deb" -exec cp {} dist/ \; 2>/dev/null || true
+          find packages/app/src-tauri/target/ -path "*/bundle/*" -name "*.rpm" -exec cp {} dist/ \; 2>/dev/null || true
           echo "Collected assets successfully:"
           ls -la dist/
 
@@ -351,3 +356,59 @@ jobs:
           # Use the modern artifact bundle flow supported by GlitchTip 4.2+.
           npx @sentry/cli@3.4.0 sourcemaps inject packages/app/build/_app/immutable
           npx @sentry/cli@3.4.0 sourcemaps upload packages/app/build/_app/immutable
+
+  # 将 updater manifest (latest.json) 发布到阿里云 OSS，作为国内网络下的兜底更新源。
+  # 思路：从 GitHub Release 拉取官方生成的 latest.json，把其中各平台安装包的 URL
+  # 前缀改写为 OSS 地址（安装包已由 build-tauri 各平台任务上传到 releases/v<版本>/），
+  # 再上传到 OSS 固定路径 releases/latest.json。
+  # 这样当 GitHub 不可达时，应用会回退到 OSS 完成检查更新与下载安装。
+  publish-oss-manifest:
+    needs: [release, build-tauri]
+    if: needs.release.outputs.released == 'true' && needs.build-tauri.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download GitHub updater manifest
+        shell: bash
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          mkdir -p dist-latest
+          curl -fsSL "https://github.com/Onin-app/Onin/releases/download/${TAG}/latest.json" -o dist-latest/latest.json
+
+      - name: Rewrite asset URLs to Aliyun OSS
+        shell: bash
+        env:
+          OSS_BASE_URL: https://onin-app.oss-cn-beijing.aliyuncs.com
+        run: |
+          node -e '
+            const fs = require("fs");
+            const path = "dist-latest/latest.json";
+            const m = JSON.parse(fs.readFileSync(path, "utf8"));
+            const GH_PREFIXES = [
+              "https://github.com/Onin-app/Onin/releases/download/",
+              "https://github.com/b-yp/Onin/releases/download/",
+            ];
+            const OSS_PREFIX = process.env.OSS_BASE_URL + "/releases/";
+            for (const key of Object.keys(m.platforms || {})) {
+              const u = m.platforms[key].url;
+              if (!u) continue;
+              for (const p of GH_PREFIXES) {
+                if (u.startsWith(p)) {
+                  m.platforms[key].url = OSS_PREFIX + u.slice(p.length);
+                  break;
+                }
+              }
+            }
+            fs.writeFileSync(path, JSON.stringify(m, null, 2));
+            console.log("Rewritten OSS manifest:", JSON.stringify(m.platforms, null, 2));
+          '
+
+      - name: Upload OSS manifest
+        uses: tiyee/aliyun-oss-auto-upload@v2.0.7
+        with:
+          region: ${{ secrets.OSS_REGION }}
+          access-key-id: ${{ secrets.OSS_ACCESS_KEY_ID }}
+          access-key-secret: ${{ secrets.OSS_ACCESS_KEY_SECRET }}
+          bucket: ${{ secrets.OSS_BUCKET }}
+          local-folder: dist-latest
+          remote-dir: releases

--- a/packages/app/src-tauri/tauri.conf.json
+++ b/packages/app/src-tauri/tauri.conf.json
@@ -67,7 +67,7 @@
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRFRjZFRkY2RDIyMDM0MTYKUldRV05DRFM5dS8yVG8vWkRCdVAyWC9OMGgwNEo0cnFLNW1VV1AzZjFQSVNnbW9zQTdUQUVyVHgK",
       "endpoints": [
         "https://github.com/Onin-app/Onin/releases/latest/download/latest.json",
-        "https://github.com/b-yp/Onin/releases/latest/download/latest.json"
+        "https://onin-app.oss-cn-beijing.aliyuncs.com/releases/latest.json"
       ]
     }
   }


### PR DESCRIPTION
GitHub 不可达时（如国内网络），应用现在会回退到阿里云 OSS 检查并下载更新。新增 publish-oss-manifest 任务：从 GitHub Release 拉取 latest.json，将各平台安装包 URL 改写为 OSS 地址后上传到 OSS 固定路径 releases/latest.json；同时收集步骤补传 manifest 引用的 .msi/.app.tar.gz/.rpm 到 OSS，避免兜底下载 404。